### PR TITLE
fix the cuda and tf warnings

### DIFF
--- a/2-dev_datascience/1-experiment_train.ipynb
+++ b/2-dev_datascience/1-experiment_train.ipynb
@@ -49,6 +49,7 @@
     "from pathlib import Path\n",
     "import pickle\n",
     "import os\n",
+    "import logging, warnings\n",
     "\n",
     "import numpy as np\n",
     "\n",
@@ -63,7 +64,12 @@
     "import pickle\n",
     "import seaborn as sns\n",
     "from matplotlib import pyplot as plt\n",
-    "import onnxruntime as rt"
+    "import onnxruntime as rt\n",
+    "\n",
+    "# Suppress CUDA and TF warnings\n",
+    "os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'\n",
+    "logging.getLogger('tensorflow').setLevel(logging.ERROR)\n",
+    "warnings.filterwarnings(\"ignore\", category=FutureWarning)"
    ]
   },
   {


### PR DESCRIPTION
Fix the CUDA and TF warnings that outputs into the 1-experiment_train.ipynb that could misslead the final user.