### PR TITLE
add modelscan extras

### DIFF
--- a/8-securing_ai/1-modelscan.ipynb
+++ b/8-securing_ai/1-modelscan.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip -q install modelscan\n",
+    "!pip -q install modelscan 'modelscan[ tensorflow ]' 'modelscan[ h5py ]'\n",
     "%env TF_CPP_MIN_LOG_LEVEL=3"
    ]
   },


### PR DESCRIPTION
Adding modelscan extras that are required for the "totally same model" to throw errors