### PR TITLE
Updating so training dataset only pulls a single song

### DIFF
--- a/7-feature_store/2-test_load_historitcal_features.ipynb
+++ b/7-feature_store/2-test_load_historitcal_features.ipynb
@@ -106,7 +106,11 @@
     "# Feast will remove rows with identical id and date so we add a small delta to each\n",
     "microsecond_deltas = np.arange(0, len(training_dataset))*2\n",
     "training_dataset['snapshot_date'] = training_dataset['snapshot_date'] + pd.to_timedelta(microsecond_deltas, unit='us')\n",
-    "training_dataset"
+    "# Lets wakeup with some Espresso ☕ and see how our data changed over time in France \n",
+    "training_dataset[\n",
+    "    (training_dataset['name'] == 'Espresso') &\n",
+    "    (training_dataset['country'] == 'FR')\n",
+    "]"
    ]
   },
   {


### PR DESCRIPTION
Talk to Robert about this, but we are showing a single song in the return table. 

The thought behind it is that we can see that one song has multiple entries with different dates. We can also see the popularity change slightly.

New output would look like this:

![image](https://github.com/user-attachments/assets/8dc1eada-901b-41bd-82ba-e7d5da9dc19b)