### PR TITLE
Fix ImportError by upgrading urllib3 post-installation

### DIFF
--- a/6-advanced_deployments/1-test_autoscale.ipynb
+++ b/6-advanced_deployments/1-test_autoscale.ipynb
@@ -18,7 +18,8 @@
    "outputs": [],
    "source": [
     "# install locust library\n",
-    "!pip -q install locust"
+    "!pip -q install locust\n",
+    "!pip install --upgrade urllib3"
    ]
   },
   {


### PR DESCRIPTION
Description: Summary Explicitly upgrades urllib3 after the locust installation to resolve a dependency conflict.

Reason for Change Running the previous build resulted in the following ImportError due to a version mismatch in urllib3:
ImportError: cannot import name 'create_urllib3_context' from 'urllib3.util' 
(/opt/app-root/lib64/python3.11/site-packages/urllib3/util/__init__.py)

Resolution Forcing an upgrade of urllib3 ensures the environment has the correct version required by the dependencies, resolving the import error.